### PR TITLE
Fix information about dependencies to be more accurate

### DIFF
--- a/README
+++ b/README
@@ -51,10 +51,10 @@ How to use
 
 1.  Make sure you are on a compatible system.
         You need Python (I used Python 2.7.10) and openssl (I used OpenSSL 1.0.2d-fips 9 Jul 2015)
-        python >= 2.6.x (3.x probably works, but I haven't tested)
+        python >= 2.6.x (currently python-3 doesn't work)
         openssl >= 1.0.x (maybe earlier versions work)
 2.  Install dependencies
-        pip install PyASN1
+        pip install PyASN1 rsa
 3.  Find your private_key.json and regr.json files in /etc/letsencrypt/accounts/
 
 Reconstruct public key:

--- a/decode_private_key_json.py
+++ b/decode_private_key_json.py
@@ -15,7 +15,7 @@ try:
     from pyasn1.type import univ, namedtype, tag
     from rsa.asn1 import AsnPubKey
 except ImportError:
-    print('This script requires PyASN1 to function. Try running: pip install PyASN1')
+    print('This script requires PyASN1 and rsa to function. Try running: pip install PyASN1 rsa')
     sys.exit(1)
 
 

--- a/decode_public_key_json.py
+++ b/decode_public_key_json.py
@@ -15,7 +15,7 @@ try:
     from pyasn1.type import univ, namedtype, tag
     from rsa.asn1 import AsnPubKey
 except ImportError:
-    print('This script requires PyASN1 to function. Try running: pip install PyASN1')
+    print('This script requires PyASN1 and rsa to function. Try running: pip install PyASN1 rsa')
     sys.exit(1)
 
 


### PR DESCRIPTION
The current README doesn't indicate that rsa is also required, says that python3 probably works whereas it does not and also programs give misleading messages about what is missing in dependencies. This PR fixes the aforementioned things.